### PR TITLE
Replace "...examples" with docker-example-omero and add prod-playbooks

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -69,9 +69,10 @@
 - name: Ansible, Docker and examples
 
   packages:
+    - repo: ome/prod-playbooks
     - repo: ome/ansible-role-omero-server
     - repo: ome/ansible-role-omero-web
-    - repo: ome/omero-deployment-examples
+    - repo: ome/docker-example-omero
     - repo: ome/omero-web-docker
     - repo: ome/omero-server-docker
 


### PR DESCRIPTION
@lubianat @joshmoore @jburel @Rdornier

First of all, thanks @lubianat for the very nice dashboard here.

The present PR is suggesting to restructure the ansible-docker section, in lines with comment at https://github.com/ome/docker-example-omero/pull/21#issuecomment-3670046064 - in a nutshell:


There are quite a few repos in https://github.com/ome/omero-deployment-examples the maintenance of which is unclear and unallocated (and quite frankly, for most of them not happening for quite a while). This was discussed with @jburel and we agree that only one will be supported/maintained going ahead. I would suggest 1 for docker and 1 for ansible.

For docker: the [docker-example-omero](https://github.com/ome/docker-example-omero)
For ansible: [prod-playbooks ](https://github.com/ome/prod-playbooks)== the main public ansible playbooks repo which is being actively maintained (the GHA is running and green there, and the playbook is also tested manually during OME Teams prod server deployments)

The present PR is trying to reflect this ^^^ suggestion.